### PR TITLE
Allow passing URL as first parameter with options object

### DIFF
--- a/src/lazy-fetch.js
+++ b/src/lazy-fetch.js
@@ -5,7 +5,7 @@ import useFetchFn from "./fetch-fn";
 import useRefreshInterval from "./refresh-interval";
 import useResetDelay from "./reset-delay";
 
-const useLazyFetch = itemToFetch => {
+const useLazyFetch = (...args) => {
 	const {
 		isFetching,
 		setIsFetching,
@@ -19,9 +19,7 @@ const useLazyFetch = itemToFetch => {
 		resetTimer
 	} = useRequestState();
 
-	let { url, resetDelay, refreshInterval, ...opts } = prepareHeaders(
-		itemToFetch
-	);
+	let { url, resetDelay, refreshInterval, ...opts } = parseArguments(args);
 
 	if (resetDelay && refreshInterval) {
 		throw new Error(
@@ -60,6 +58,30 @@ const useLazyFetch = itemToFetch => {
 		fetch: fetchFn
 	};
 };
+
+function parseArguments(args) {
+	if (args) {
+		if (args.length == 1) {
+			return prepareHeaders(args[0]);
+		}
+
+		if (args.length == 2) {
+			if (isString(args[1])) {
+				throw new Error(
+					"The second argument to the fetch hook should be an options object, not a string."
+				);
+			}
+
+			return prepareHeaders({ ...args[1], url: args[0] });
+		}
+
+		throw new Error(
+			"The fetch hook only takes one or two arguments. See usage instructions: https://github.com/civicsource/react-fetch-hooks/blob/master/README.md"
+		);
+	}
+
+	return {};
+}
 
 function prepareHeaders(itemToFetch) {
 	let { url, bearerToken, ...opts } = itemToFetch || {};

--- a/src/use-fetch.js
+++ b/src/use-fetch.js
@@ -1,12 +1,12 @@
 import { useEffect } from "react";
 import useLazyFetch from "./lazy-fetch";
 
-const useFetch = itemToFetch => {
-	const { fetch: doTheFetch, ...result } = useLazyFetch(itemToFetch);
+const useFetch = (...args) => {
+	const { fetch: doTheFetch, ...result } = useLazyFetch(...args);
 
 	// JSON.stringify: just relax, it's fine
 	// https://github.com/facebook/react/issues/14476#issuecomment-471199055
-	useEffect(doTheFetch, [JSON.stringify(itemToFetch)]);
+	useEffect(doTheFetch, [JSON.stringify(args)]);
 
 	return result;
 };


### PR DESCRIPTION
This more closely aligns with `fetch` API which is what we are trying to mirror.

This fixes #2.