### PR TITLE
Fix IE issues when using useFetch with string argument

### DIFF
--- a/src/lazy-fetch.js
+++ b/src/lazy-fetch.js
@@ -84,12 +84,15 @@ function parseArguments(args) {
 }
 
 function prepareHeaders(itemToFetch) {
-	let url, bearerToken, opts = {};
+	let url,
+		bearerToken,
+		opts = {};
 
 	if (isString(itemToFetch)) {
 		url = itemToFetch;
 	} else {
-		const { url: _url, bearerToken: _bearerToken, ..._opts } = itemToFetch || {};
+		const { url: _url, bearerToken: _bearerToken, ..._opts } =
+			itemToFetch || {};
 		url = _url;
 		bearerToken = _bearerToken;
 		opts = _opts;

--- a/src/lazy-fetch.js
+++ b/src/lazy-fetch.js
@@ -84,7 +84,7 @@ function parseArguments(args) {
 }
 
 function prepareHeaders(itemToFetch) {
-	let url, bearerToken, opts;
+	let url, bearerToken, opts = {};
 
 	if (isString(itemToFetch)) {
 		url = itemToFetch;

--- a/src/lazy-fetch.js
+++ b/src/lazy-fetch.js
@@ -84,10 +84,15 @@ function parseArguments(args) {
 }
 
 function prepareHeaders(itemToFetch) {
-	let { url, bearerToken, ...opts } = itemToFetch || {};
+	let url, bearerToken, opts;
 
-	if (!url && isString(itemToFetch)) {
+	if (isString(itemToFetch)) {
 		url = itemToFetch;
+	} else {
+		const { url: _url, bearerToken: _bearerToken, ..._opts } = itemToFetch || {};
+		url = _url;
+		bearerToken = _bearerToken;
+		opts = _opts;
 	}
 
 	let { headers, ...otherOpts } = opts;


### PR DESCRIPTION
The failing internet explorer errors on `Object.getOwnProperties` (as opposed to returning an array of string characters in Chrome, Edge, and other post proterozoic era web browsers) if a non-object is passed in. When destructuring, the compiled `lazy-fetch` uses `Object.getOwnProperties` in the `prepareHeaders` function. This breaks if a string is passed into `use-fetch` or `use-lazy-fetch`.

The solution was to move the string check before the destructuring, which also meant having to manually assign our destructured variables to the `prepareHeaders` function scope.