### PR TITLE
Extend the API to expose response as body, headers, deprecating data

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "mochaExplorer.files": "test/*.js",
+    "mochaExplorer.env": {
+        "BABEL_ENV": "node"
+    },
+    "mochaExplorer.require": ["test/babel-register"]
+}

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 > A set of react hooks to work with the fetch API and gracefully parse & deal with HTTP errors.
 
 ```js
-const { isFetching, isFetched, error, data } =
+const { isFetching, isFetched, error, body } =
 		useFetch(`https://api.example.com/`);
 ```
 
 or
 
 ```js
-const { isFetching, isFetched, error, data: result, fetch: saveThing } =
+const { isFetching, isFetched, error, body: result, fetch: saveThing } =
 		useLazyFetch(`https://api.example.com/`, {
 			method: "POST"
 		});
@@ -60,7 +60,7 @@ import React from "react";
 import { useFetch } from "react-fetch-hooks";
 
 const MyBanana = ({ id }) => {
-	const { isFetching, isFetched, error, data: banana } =
+	const { isFetching, isFetched, error, body: banana } =
 		useFetch(`https://api.example.com/bananas/${id}`);
 
 	if (isFetching) {
@@ -76,7 +76,7 @@ const MyBanana = ({ id }) => {
 };
 ```
 
-This will make a `GET` request to `api.example.com` whenever the `id` prop passed to the component changes. It will then return the status of the data being loaded as well as the data when it is ready. The `useFetch` hook takes all the same parameters/options as the [standard fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
+This will make a `GET` request to `api.example.com` whenever the `id` prop passed to the component changes. It will then return the status of the response body being loaded as well as the body itself when it is ready. The `useFetch` hook takes all the same parameters/options as the [standard fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
 
 ### Lazy Evaluation
 
@@ -117,7 +117,7 @@ import React from "react";
 import { useFetch } from "react-fetch-hooks";
 
 const MyBanana = ({ id }) => {
-	const { data: banana } = useFetch({
+	const { body: banana } = useFetch({
 		url: `https://api.example.com/bananas/${id}`,
 		refreshInterval: 10000
 	});
@@ -168,7 +168,7 @@ import React from "react";
 import { useFetch } from "react-fetch-hooks";
 
 const MyBanana = ({ id }) => {
-	const { data: banana } = useFetch(id ? `https://api.example.com/bananas/${id}` : null);
+	const { body: banana } = useFetch(id ? `https://api.example.com/bananas/${id}` : null);
 
 	if (!banana) return null;
 	return <span>My banana is {banana.color}!</span>;
@@ -204,7 +204,7 @@ import React from "react";
 import { useFetch } from "react-fetch-hooks";
 
 const MyBanana = ({ id, authToken = "mytoken" }) => {
-	const { data: banana } = useFetch(`https://api.example.com/bananas/${id}`, {
+	const { body: banana } = useFetch(`https://api.example.com/bananas/${id}`, {
 		bearerToken: authToken
 	});
 

--- a/src/check-status.js
+++ b/src/check-status.js
@@ -9,10 +9,10 @@ export default async function checkStatus(response) {
 }
 
 async function parseJSONError(response) {
-	let data;
+	let _body;
 
 	try {
-		data = await response.json();
+		_body = await response.json();
 	} catch {
 		// there was an error trying to parse the JSON body (maybe it's not JSON?)
 		// just ignore it and return an error with the original response without a parsed body
@@ -24,7 +24,7 @@ async function parseJSONError(response) {
 		throw error;
 	}
 
-	let msg = extractErrorMessage(data);
+	let msg = extractErrorMessage(_body);
 	if (!msg) msg = response.statusText;
 
 	let error = new Error(msg);
@@ -32,7 +32,7 @@ async function parseJSONError(response) {
 		status: response.status,
 		type: response.type,
 		url: response.url,
-		body: data
+		body: _body
 	};
 
 	throw error;

--- a/src/fetch-fn.js
+++ b/src/fetch-fn.js
@@ -10,8 +10,8 @@ const useFetchFn = ({
 	setIsFetching,
 	setIsFetched,
 	setError,
-	setData,
-	setResponse
+	setBody,
+	setHeaders
 }) =>
 	useCallback(() => {
 		resetTimer(0);
@@ -25,24 +25,22 @@ const useFetchFn = ({
 		async function doFetch() {
 			try {
 				let _response = await fetch(url, opts);
-				let data;
-				let response = { headers: undefined, body: undefined };
+				let _headers;
+				let _body;
 
 				_response = await checkStatus(_response);
 
-				response.headers = _response.headers;
+				_headers = _response.headers;
 
 				if (_response.status != 204) {
-					data = await _response.json();
-					response.body = data;
+					_body = await _response.json();
 				} else {
 					// for 204 No Content, just return null data
-					data = null;
-					response.body = null;
+					_body = null;
 				}
 
-				setData(data);
-				setResponse(response);
+				setBody(_body);
+				setHeaders(_headers);
 				setIsFetching(false);
 				setIsFetched(true);
 				setError(null);

--- a/src/fetch-fn.js
+++ b/src/fetch-fn.js
@@ -10,7 +10,8 @@ const useFetchFn = ({
 	setIsFetching,
 	setIsFetched,
 	setError,
-	setData
+	setData,
+	setResponse
 }) =>
 	useCallback(() => {
 		resetTimer(0);
@@ -23,18 +24,25 @@ const useFetchFn = ({
 
 		async function doFetch() {
 			try {
-				let response = await fetch(url, opts);
+				let _response = await fetch(url, opts);
+				let data;
+				let response = { headers: undefined, body: undefined };
 
-				response = await checkStatus(response);
+				_response = await checkStatus(_response);
 
-				if (response.status != 204) {
-					response = await response.json();
+				response.headers = _response.headers;
+
+				if (_response.status != 204) {
+					data = await _response.json();
+					response.body = data;
 				} else {
 					// for 204 No Content, just return null data
-					response = null;
+					data = null;
+					response.body = null;
 				}
 
-				setData(response);
+				setData(data);
+				setResponse(response);
 				setIsFetching(false);
 				setIsFetched(true);
 				setError(null);

--- a/src/lazy-fetch.js
+++ b/src/lazy-fetch.js
@@ -11,10 +11,10 @@ const useLazyFetch = (...args) => {
 		setIsFetching,
 		isFetched,
 		setIsFetched,
-		data,
-		setData,
-		response,
-		setResponse,
+		body,
+		setBody,
+		headers,
+		setHeaders,
 		error,
 		setError,
 		timerSignal,
@@ -38,13 +38,13 @@ const useLazyFetch = (...args) => {
 		setIsFetching,
 		setIsFetched,
 		setError,
-		setData,
-		setResponse
+		setBody,
+		setHeaders
 	});
 
 	useResetDelay({
 		resetDelay,
-		setData,
+		setBody,
 		setError,
 		setIsFetched,
 		setIsFetching,
@@ -56,8 +56,8 @@ const useLazyFetch = (...args) => {
 	return {
 		isFetching,
 		isFetched,
-		data,
-		response,
+		body,
+		headers,
 		error,
 		fetch: fetchFn
 	};

--- a/src/lazy-fetch.js
+++ b/src/lazy-fetch.js
@@ -45,6 +45,7 @@ const useLazyFetch = (...args) => {
 	useResetDelay({
 		resetDelay,
 		setBody,
+		setHeaders,
 		setError,
 		setIsFetched,
 		setIsFetching,

--- a/src/lazy-fetch.js
+++ b/src/lazy-fetch.js
@@ -13,6 +13,8 @@ const useLazyFetch = (...args) => {
 		setIsFetched,
 		data,
 		setData,
+		response,
+		setResponse,
 		error,
 		setError,
 		timerSignal,
@@ -36,7 +38,8 @@ const useLazyFetch = (...args) => {
 		setIsFetching,
 		setIsFetched,
 		setError,
-		setData
+		setData,
+		setResponse
 	});
 
 	useResetDelay({
@@ -54,6 +57,7 @@ const useLazyFetch = (...args) => {
 		isFetching,
 		isFetched,
 		data,
+		response,
 		error,
 		fetch: fetchFn
 	};

--- a/src/request-state.js
+++ b/src/request-state.js
@@ -3,6 +3,7 @@ import { useState } from "react";
 const useIsFetching = () => useState(false);
 const useIsFetched = () => useState(false);
 const useData = () => useState(null);
+const useResponse = () => useState({});
 const useError = () => useState(null);
 const useTimerSignal = () => useState(0);
 
@@ -10,6 +11,7 @@ const useRequestInitialState = () => {
 	const [isFetching, setIsFetching] = useIsFetching();
 	const [isFetched, setIsFetched] = useIsFetched();
 	const [data, setData] = useData();
+	const [response, setResponse] = useResponse();
 	const [error, setError] = useError();
 	const [timerSignal, resetTimer] = useTimerSignal();
 
@@ -20,6 +22,8 @@ const useRequestInitialState = () => {
 		setIsFetched,
 		data,
 		setData,
+		response,
+		setResponse,
 		error,
 		setError,
 		timerSignal,

--- a/src/request-state.js
+++ b/src/request-state.js
@@ -2,16 +2,16 @@ import { useState } from "react";
 
 const useIsFetching = () => useState(false);
 const useIsFetched = () => useState(false);
-const useData = () => useState(null);
-const useResponse = () => useState({});
+const useBody = () => useState(null);
+const useHeaders = () => useState(null);
 const useError = () => useState(null);
 const useTimerSignal = () => useState(0);
 
 const useRequestInitialState = () => {
 	const [isFetching, setIsFetching] = useIsFetching();
 	const [isFetched, setIsFetched] = useIsFetched();
-	const [data, setData] = useData();
-	const [response, setResponse] = useResponse();
+	const [body, setBody] = useBody();
+	const [headers, setHeaders] = useHeaders();
 	const [error, setError] = useError();
 	const [timerSignal, resetTimer] = useTimerSignal();
 
@@ -20,10 +20,10 @@ const useRequestInitialState = () => {
 		setIsFetching,
 		isFetched,
 		setIsFetched,
-		data,
-		setData,
-		response,
-		setResponse,
+		body,
+		setBody,
+		headers,
+		setHeaders,
 		error,
 		setError,
 		timerSignal,

--- a/src/reset-delay.js
+++ b/src/reset-delay.js
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 
 const useResetDelay = ({
 	resetDelay,
-	setData,
+	setBody,
 	setError,
 	setIsFetched,
 	setIsFetching,
@@ -13,7 +13,7 @@ const useResetDelay = ({
 		if (timerSignal && resetDelay) {
 			timer = setTimeout(() => {
 				// reset the state
-				setData(null);
+				setBody(null);
 				setIsFetching(false);
 				setIsFetched(false);
 				setError(null);
@@ -21,6 +21,6 @@ const useResetDelay = ({
 		}
 
 		return () => timer && clearTimeout(timer);
-	}, [resetDelay, setData, setError, setIsFetched, setIsFetching, timerSignal]);
+	}, [resetDelay, setBody, setError, setIsFetched, setIsFetching, timerSignal]);
 
 export default useResetDelay;

--- a/src/reset-delay.js
+++ b/src/reset-delay.js
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 const useResetDelay = ({
 	resetDelay,
 	setBody,
+	setHeaders,
 	setError,
 	setIsFetched,
 	setIsFetching,
@@ -14,6 +15,7 @@ const useResetDelay = ({
 			timer = setTimeout(() => {
 				// reset the state
 				setBody(null);
+				setHeaders(null);
 				setIsFetching(false);
 				setIsFetched(false);
 				setError(null);
@@ -21,6 +23,14 @@ const useResetDelay = ({
 		}
 
 		return () => timer && clearTimeout(timer);
-	}, [resetDelay, setBody, setError, setIsFetched, setIsFetching, timerSignal]);
+	}, [
+		resetDelay,
+		setBody,
+		setHeaders,
+		setError,
+		setIsFetched,
+		setIsFetching,
+		timerSignal
+	]);
 
 export default useResetDelay;

--- a/test/using-fetch.js
+++ b/test/using-fetch.js
@@ -33,16 +33,16 @@ describe("Using fetch hook", function() {
 			expect(req.headers["Content-Type"]).to.equal("application/json");
 		});
 
-		it("should indicate the data is fetching", function() {
+		it("should indicate the body is fetching", function() {
 			expect(this.result.current).to.be.ok;
 
-			const { isFetching, isFetched, error, data } = this.result.current;
+			const { isFetching, isFetched, error, body } = this.result.current;
 
 			expect(isFetching).to.be.true;
 			expect(isFetched).to.be.false;
 			expect(error).to.not.be.ok;
 
-			expect(data).to.not.be.ok;
+			expect(body).to.not.be.ok;
 		});
 
 		describe("with a successful server response", function() {
@@ -62,25 +62,24 @@ describe("Using fetch hook", function() {
 			it("should return results as loaded", function() {
 				expect(this.result.current).to.be.ok;
 
-				const { isFetching, isFetched, error, data } = this.result.current;
+				const { isFetching, isFetched, error, body } = this.result.current;
 
 				expect(isFetching).to.be.false;
 				expect(isFetched).to.be.true;
 				expect(error).to.not.be.ok;
 
-				expect(data).to.be.ok;
-				expect(data).to.have.lengthOf(2);
-				expect(data[0]).to.equal("ripe banana");
-				expect(data[1]).to.equal("green banana");
+				expect(body).to.be.ok;
+				expect(body).to.have.lengthOf(2);
+				expect(body[0]).to.equal("ripe banana");
+				expect(body[1]).to.equal("green banana");
 			});
 
-			it("should return response with headers and body", function() {
+			it("should return with headers and body", function() {
 				const current = this.result.current;
 
-				expect(current.response).to.exist;
-				expect(current.response.headers).to.exist;
-				expect(current.response.body).to.exist;
-				expect(current.response.headers).to.deep.equal({
+				expect(current.headers).to.exist;
+				expect(current.body).to.exist;
+				expect(current.headers).to.deep.equal({
 					"Content-Type": "application/json"
 				});
 			});
@@ -114,7 +113,7 @@ describe("Using fetch hook", function() {
 			it("should return results as errored", function() {
 				expect(this.result.current).to.be.ok;
 
-				const { isFetching, isFetched, error, data } = this.result.current;
+				const { isFetching, isFetched, error, body } = this.result.current;
 
 				expect(isFetching).to.be.false;
 				expect(isFetched).to.be.false;
@@ -126,7 +125,7 @@ describe("Using fetch hook", function() {
 				expect(error.response).to.be.ok;
 				expect(error.response.status).to.equal(500);
 
-				expect(data).to.not.be.ok;
+				expect(body).to.not.be.ok;
 			});
 
 			describe("and then setting setting arbitrary props on the component", function() {
@@ -166,13 +165,13 @@ describe("Using fetch hook", function() {
 		it("should return results as fetching", function() {
 			expect(this.result.current).to.be.ok;
 
-			const { isFetching, isFetched, error, data } = this.result.current;
+			const { isFetching, isFetched, error, body } = this.result.current;
 
 			expect(isFetching).to.be.true;
 			expect(isFetched).to.be.false;
 			expect(error).to.not.be.ok;
 
-			expect(data).to.not.be.ok;
+			expect(body).to.not.be.ok;
 		});
 
 		describe("with a successful server response", function() {
@@ -189,16 +188,16 @@ describe("Using fetch hook", function() {
 			it("should return results as fetched", function() {
 				expect(this.result.current).to.be.ok;
 
-				const { isFetching, isFetched, error, data } = this.result.current;
+				const { isFetching, isFetched, error, body } = this.result.current;
 
 				expect(isFetching).to.be.false;
 				expect(isFetched).to.be.true;
 				expect(error).to.not.be.ok;
 
-				expect(data).to.be.ok;
-				expect(data).to.have.lengthOf(2);
-				expect(data[0]).to.equal("ripe banana");
-				expect(data[1]).to.equal("green banana");
+				expect(body).to.be.ok;
+				expect(body).to.have.lengthOf(2);
+				expect(body[0]).to.equal("ripe banana");
+				expect(body[1]).to.equal("green banana");
 			});
 
 			describe("and then setting a keyed prop on the component", function() {
@@ -215,19 +214,19 @@ describe("Using fetch hook", function() {
 					);
 				});
 
-				it("should return results as fetching and still pass previously loaded data", function() {
+				it("should return results as fetching and still pass previously loaded body", function() {
 					expect(this.result.current).to.be.ok;
 
-					const { isFetching, isFetched, error, data } = this.result.current;
+					const { isFetching, isFetched, error, body } = this.result.current;
 
 					expect(isFetching).to.be.true;
 					expect(isFetched).to.be.true;
 					expect(error).to.not.be.ok;
 
-					expect(data).to.be.ok;
-					expect(data).to.have.lengthOf(2);
-					expect(data[0]).to.equal("ripe banana");
-					expect(data[1]).to.equal("green banana");
+					expect(body).to.be.ok;
+					expect(body).to.have.lengthOf(2);
+					expect(body[0]).to.equal("ripe banana");
+					expect(body[1]).to.equal("green banana");
 				});
 
 				describe("with another successful server response", function() {
@@ -241,19 +240,19 @@ describe("Using fetch hook", function() {
 						setTimeout(done, 10);
 					});
 
-					it("should return newly loaded data", function() {
+					it("should return newly loaded body", function() {
 						expect(this.result.current).to.be.ok;
 
-						const { isFetching, isFetched, error, data } = this.result.current;
+						const { isFetching, isFetched, error, body } = this.result.current;
 
 						expect(isFetching).to.be.false;
 						expect(isFetched).to.be.true;
 						expect(error).to.not.be.ok;
 
-						expect(data).to.be.ok;
-						expect(data).to.have.lengthOf(2);
-						expect(data[0]).to.equal("purple banana");
-						expect(data[1]).to.equal("orange banana");
+						expect(body).to.be.ok;
+						expect(body).to.have.lengthOf(2);
+						expect(body[0]).to.equal("purple banana");
+						expect(body[1]).to.equal("orange banana");
 					});
 				});
 			});
@@ -287,7 +286,7 @@ describe("Using fetch hook", function() {
 			it("should return result as errored", function() {
 				expect(this.result.current).to.be.ok;
 
-				const { isFetching, isFetched, error, data } = this.result.current;
+				const { isFetching, isFetched, error, body } = this.result.current;
 
 				expect(isFetching).to.be.false;
 				expect(isFetched).to.be.false;
@@ -299,7 +298,7 @@ describe("Using fetch hook", function() {
 				expect(error.response).to.be.ok;
 				expect(error.response.status).to.equal(500);
 
-				expect(data).to.not.be.ok;
+				expect(body).to.not.be.ok;
 			});
 
 			describe("and then setting a keyed prop on the component", function() {
@@ -319,13 +318,13 @@ describe("Using fetch hook", function() {
 				it("should return result as fetching and no longer errored", function() {
 					expect(this.result.current).to.be.ok;
 
-					const { isFetching, isFetched, error, data } = this.result.current;
+					const { isFetching, isFetched, error, body } = this.result.current;
 
 					expect(isFetching).to.be.true;
 					expect(isFetched).to.be.false;
 					expect(error).to.not.be.ok;
 
-					expect(data).to.not.be.ok;
+					expect(body).to.not.be.ok;
 				});
 			});
 
@@ -420,15 +419,15 @@ describe("Using fetch hook", function() {
 			setTimeout(done, 10);
 		});
 
-		it("should return null data", function() {
+		it("should return null body", function() {
 			expect(this.result.current).to.be.ok;
 
-			const { isFetching, isFetched, error, data } = this.result.current;
+			const { isFetching, isFetched, error, body } = this.result.current;
 
 			expect(isFetching).to.be.false;
 			expect(isFetched).to.be.true;
 			expect(error).to.not.be.ok;
-			expect(data).to.not.be.ok;
+			expect(body).to.not.be.ok;
 		});
 	});
 
@@ -455,7 +454,7 @@ describe("Using fetch hook", function() {
 		it("should return lazy function and fetch results", function() {
 			expect(this.result.current).to.be.ok;
 
-			const { fetch, isFetching, isFetched, error, data } = this.result.current;
+			const { fetch, isFetching, isFetched, error, body } = this.result.current;
 
 			expect(fetch).to.be.ok;
 			expect(fetch).to.be.a("function");
@@ -464,7 +463,7 @@ describe("Using fetch hook", function() {
 			expect(isFetched).to.be.false;
 			expect(error).to.not.be.ok;
 
-			expect(data).to.not.be.ok;
+			expect(body).to.not.be.ok;
 		});
 
 		describe("and then invoking the lazy function", function() {
@@ -487,13 +486,13 @@ describe("Using fetch hook", function() {
 			it("should return fetch results", function() {
 				expect(this.result.current).to.be.ok;
 
-				const { isFetching, isFetched, error, data } = this.result.current;
+				const { isFetching, isFetched, error, body } = this.result.current;
 
 				expect(isFetching).to.be.true;
 				expect(isFetched).to.be.false;
 				expect(error).to.not.be.ok;
 
-				expect(data).to.not.be.ok;
+				expect(body).to.not.be.ok;
 			});
 		});
 
@@ -511,7 +510,7 @@ describe("Using fetch hook", function() {
 					setTimeout(done, 10);
 				});
 
-				it("should make a fetch API request with new body data", function() {
+				it("should make a fetch API request with new body body", function() {
 					expect(this.requests.length).to.equal(1);
 
 					const req = this.requests[0];
@@ -549,13 +548,13 @@ describe("Using fetch hook", function() {
 			it("should return result", function() {
 				expect(this.result.current).to.be.ok;
 
-				const { isFetching, isFetched, error, data } = this.result.current;
+				const { isFetching, isFetched, error, body } = this.result.current;
 
 				expect(isFetching).to.be.false;
 				expect(isFetched).to.be.true;
 				expect(error).to.not.be.ok;
 
-				expect(data).to.deep.equal({ name: "Bob" });
+				expect(body).to.deep.equal({ name: "Bob" });
 			});
 
 			describe("and then waiting the reset threshold time", function() {
@@ -563,16 +562,16 @@ describe("Using fetch hook", function() {
 					setTimeout(done, 110);
 				});
 
-				it("should clear result data", function() {
+				it("should clear result body", function() {
 					expect(this.result.current).to.be.ok;
 
-					const { isFetching, isFetched, error, data } = this.result.current;
+					const { isFetching, isFetched, error, body } = this.result.current;
 
 					expect(isFetching).to.be.false;
 					expect(isFetched).to.be.false;
 					expect(error).to.not.be.ok;
 
-					expect(data).to.not.be.ok;
+					expect(body).to.not.be.ok;
 				});
 			});
 
@@ -587,13 +586,13 @@ describe("Using fetch hook", function() {
 				it("should mark status as refetching", function() {
 					expect(this.result.current).to.be.ok;
 
-					const { isFetching, isFetched, error, data } = this.result.current;
+					const { isFetching, isFetched, error, body } = this.result.current;
 
 					expect(isFetching).to.be.true;
 					expect(isFetched).to.be.true;
 					expect(error).to.not.be.ok;
 
-					expect(data).to.deep.equal({ name: "Bob" });
+					expect(body).to.deep.equal({ name: "Bob" });
 				});
 
 				describe("and then waiting enough time for the original reset", function() {
@@ -601,20 +600,20 @@ describe("Using fetch hook", function() {
 						setTimeout(done, 60);
 					});
 
-					it("should not reset data", function() {
+					it("should not reset body", function() {
 						expect(this.result.current).to.be.ok;
 
-						const { isFetching, isFetched, error, data } = this.result.current;
+						const { isFetching, isFetched, error, body } = this.result.current;
 
 						expect(isFetching).to.be.true;
 						expect(isFetched).to.be.true;
 						expect(error).to.not.be.ok;
 
-						expect(data).to.deep.equal({ name: "Bob" });
+						expect(body).to.deep.equal({ name: "Bob" });
 					});
 				});
 
-				describe("and then receiving data and waiting past the original reset time", function() {
+				describe("and then receiving body and waiting past the original reset time", function() {
 					beforeEach(function(done) {
 						this.requests.pop().resolve({
 							status: 200,
@@ -625,16 +624,16 @@ describe("Using fetch hook", function() {
 						setTimeout(done, 60);
 					});
 
-					it("should not reset data", function() {
+					it("should not reset body", function() {
 						expect(this.result.current).to.be.ok;
 
-						const { isFetching, isFetched, error, data } = this.result.current;
+						const { isFetching, isFetched, error, body } = this.result.current;
 
 						expect(isFetching).to.be.false;
 						expect(isFetched).to.be.true;
 						expect(error).to.not.be.ok;
 
-						expect(data).to.deep.equal({ name: "Homer" });
+						expect(body).to.deep.equal({ name: "Homer" });
 					});
 
 					describe("and then waiting for the next reset threshold time", function() {
@@ -642,21 +641,21 @@ describe("Using fetch hook", function() {
 							setTimeout(done, 110);
 						});
 
-						it("should clear the result data", function() {
+						it("should clear the result body", function() {
 							expect(this.result.current).to.be.ok;
 
 							const {
 								isFetching,
 								isFetched,
 								error,
-								data
+								body
 							} = this.result.current;
 
 							expect(isFetching).to.be.false;
 							expect(isFetched).to.be.false;
 							expect(error).to.not.be.ok;
 
-							expect(data).to.not.be.ok;
+							expect(body).to.not.be.ok;
 						});
 					});
 				});
@@ -712,13 +711,13 @@ describe("Using fetch hook", function() {
 				it("should return result", function() {
 					expect(this.result.current).to.be.ok;
 
-					const { isFetching, isFetched, error, data } = this.result.current;
+					const { isFetching, isFetched, error, body } = this.result.current;
 
 					expect(isFetching).to.be.false;
 					expect(isFetched).to.be.true;
 					expect(error).to.not.be.ok;
 
-					expect(data).to.deep.equal({ color: "Yellow" });
+					expect(body).to.deep.equal({ color: "Yellow" });
 				});
 
 				describe("and then waiting the refresh threshold time", function() {
@@ -726,16 +725,16 @@ describe("Using fetch hook", function() {
 						setTimeout(done, 100);
 					});
 
-					it("should mark data as loading without clearing data", function() {
+					it("should mark body as loading without clearing body", function() {
 						expect(this.result.current).to.be.ok;
 
-						const { isFetching, isFetched, error, data } = this.result.current;
+						const { isFetching, isFetched, error, body } = this.result.current;
 
 						expect(isFetching).to.be.true;
 						expect(isFetched).to.be.true;
 						expect(error).to.not.be.ok;
 
-						expect(data).to.deep.equal({ color: "Yellow" });
+						expect(body).to.deep.equal({ color: "Yellow" });
 					});
 				});
 
@@ -750,13 +749,13 @@ describe("Using fetch hook", function() {
 					it("should mark status as refetching", function() {
 						expect(this.result.current).to.be.ok;
 
-						const { isFetching, isFetched, error, data } = this.result.current;
+						const { isFetching, isFetched, error, body } = this.result.current;
 
 						expect(isFetching).to.be.true;
 						expect(isFetched).to.be.true;
 						expect(error).to.not.be.ok;
 
-						expect(data).to.deep.equal({ color: "Yellow" });
+						expect(body).to.deep.equal({ color: "Yellow" });
 					});
 
 					describe("and then waiting enough time for the original refresh", function() {
@@ -770,21 +769,21 @@ describe("Using fetch hook", function() {
 							setTimeout(done, 80);
 						});
 
-						it("should not refresh data", function() {
+						it("should not refresh body", function() {
 							expect(this.result.current).to.be.ok;
 
 							const {
 								isFetching,
 								isFetched,
 								error,
-								data
+								body
 							} = this.result.current;
 
 							expect(isFetching).to.be.false;
 							expect(isFetched).to.be.true;
 							expect(error).to.not.be.ok;
 
-							expect(data).to.deep.equal({ color: "Brown" });
+							expect(body).to.deep.equal({ color: "Brown" });
 						});
 
 						describe("and then waiting for the next refresh time", function() {
@@ -792,21 +791,21 @@ describe("Using fetch hook", function() {
 								setTimeout(done, 110);
 							});
 
-							it("should refresh the data", function() {
+							it("should refresh the body", function() {
 								expect(this.result.current).to.be.ok;
 
 								const {
 									isFetching,
 									isFetched,
 									error,
-									data
+									body
 								} = this.result.current;
 
 								expect(isFetching).to.be.true;
 								expect(isFetched).to.be.true;
 								expect(error).to.not.be.ok;
 
-								expect(data).to.deep.equal({ color: "Brown" });
+								expect(body).to.deep.equal({ color: "Brown" });
 							});
 						});
 					});
@@ -868,16 +867,16 @@ describe("Using fetch hook", function() {
 				expect(this.requests.length).to.equal(0);
 			});
 
-			it("should return empty result data", function() {
+			it("should return empty result body", function() {
 				expect(this.result.current).to.be.ok;
 
-				const { isFetching, isFetched, error, data } = this.result.current;
+				const { isFetching, isFetched, error, body } = this.result.current;
 
 				expect(isFetching).to.be.false;
 				expect(isFetched).to.be.false;
 				expect(error).to.not.be.ok;
 
-				expect(data).to.not.be.ok;
+				expect(body).to.not.be.ok;
 			});
 		}
 

--- a/test/using-fetch.js
+++ b/test/using-fetch.js
@@ -50,6 +50,9 @@ describe("Using fetch hook", function() {
 				this.requests.pop().resolve({
 					status: 200,
 					statusText: "OK",
+					headers: {
+						"Content-Type": "application/json"
+					},
 					json: async () => ["ripe banana", "green banana"]
 				});
 
@@ -69,6 +72,17 @@ describe("Using fetch hook", function() {
 				expect(data).to.have.lengthOf(2);
 				expect(data[0]).to.equal("ripe banana");
 				expect(data[1]).to.equal("green banana");
+			});
+
+			it("should return response with headers and body", function() {
+				const current = this.result.current;
+
+				expect(current.response).to.exist;
+				expect(current.response.headers).to.exist;
+				expect(current.response.body).to.exist;
+				expect(current.response.headers).to.deep.equal({
+					"Content-Type": "application/json"
+				});
 			});
 
 			describe("and then setting setting arbitrary props on the component", function() {

--- a/test/using-fetch.js
+++ b/test/using-fetch.js
@@ -539,6 +539,9 @@ describe("Using fetch hook", function() {
 				this.requests.pop().resolve({
 					status: 200,
 					statusText: "OK",
+					headers: {
+						"Content-Type": "application/json"
+					},
 					json: async () => ({ name: "Bob" })
 				});
 
@@ -562,16 +565,23 @@ describe("Using fetch hook", function() {
 					setTimeout(done, 110);
 				});
 
-				it("should clear result body", function() {
+				it("should clear result body and headers", function() {
 					expect(this.result.current).to.be.ok;
 
-					const { isFetching, isFetched, error, body } = this.result.current;
+					const {
+						isFetching,
+						isFetched,
+						error,
+						body,
+						headers
+					} = this.result.current;
 
 					expect(isFetching).to.be.false;
 					expect(isFetched).to.be.false;
 					expect(error).to.not.be.ok;
 
 					expect(body).to.not.be.ok;
+					expect(headers).to.not.be.ok;
 				});
 			});
 


### PR DESCRIPTION
`data` is still there as the response body, but there's now also a response object with the underlying response's headers.
Fixes #6